### PR TITLE
Validate destination name uniqueness on create

### DIFF
--- a/src/main/java/com/back/routopia/controller/DestinoController.java
+++ b/src/main/java/com/back/routopia/controller/DestinoController.java
@@ -36,29 +36,32 @@ public class DestinoController {
 
     @Operation(summary = "Get all Destinos")
     @GetMapping
-    public ResponseEntity<List<DestinoDTO>> find_all_destino(@RequestParam(required = false) Category category, @RequestParam(required = false) String q){
-        List<Destino> destinos = destinoService.list_all(category, q);
+    public ResponseEntity<org.springframework.data.domain.Page<DestinoDTO>> find_all_destino(
+            @RequestParam(required = false) Category category,
+            @RequestParam(required = false) String q,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ){
+        org.springframework.data.domain.Page<Destino> destinosPage = destinoService.list_all(category, q, page, size);
 
-        List<DestinoDTO> response_list = destinos.stream()
-                .map(destino -> new DestinoDTO(
-                        destino.getName(),
-                        destino.getId(),
-                        destino.getCategory().name(),
-                        destino.getCity(),
-                        destino.getPrecio(),
-                        destino.getDuration_time(),
-                        destino.getDescription(),
-                        destino.getAddress(),
-                        destino.getLanguages().stream()
-                                .map(Language::name)
-                                .collect(Collectors.toSet()),
-                        destino.getPunctuation(),
-                        destino.getImageUrl(),
-                        destino.getSecondaryImages()
-                ))
-                .toList();
+        org.springframework.data.domain.Page<DestinoDTO> responsePage = destinosPage.map(destino -> new DestinoDTO(
+                destino.getName(),
+                destino.getId(),
+                destino.getCategory().name(),
+                destino.getCity(),
+                destino.getPrecio(),
+                destino.getDuration_time(),
+                destino.getDescription(),
+                destino.getAddress(),
+                destino.getLanguages().stream()
+                        .map(Language::name)
+                        .collect(java.util.stream.Collectors.toSet()),
+                destino.getPunctuation(),
+                destino.getImageUrl(),
+                destino.getSecondaryImages()
+        ));
 
-        return ResponseEntity.ok(response_list);
+        return ResponseEntity.ok(responsePage);
     }
 
     @Operation(summary = "Get Destino by id")
@@ -76,7 +79,7 @@ public class DestinoController {
                 destino.getDuration_time(),
                 destino.getDescription(),
                 destino.getAddress(),
-                destino.getLanguages().stream().map(Language::name).collect(Collectors.toSet()),
+                destino.getLanguages().stream().map(Language::name).collect(java.util.stream.Collectors.toSet()),
                 destino.getPunctuation(),
                 destino.getImageUrl(),
                 destino.getSecondaryImages()
@@ -110,9 +113,9 @@ public class DestinoController {
         destino.setPunctuation(score);
         destino.setCity(city);
 
-        Set<Language> languageSet = languages.stream()
-                .map(Language::valueOf)
-                .collect(Collectors.toSet());
+        Set<com.back.routopia.entity.Language> languageSet = languages.stream()
+                .map(com.back.routopia.entity.Language::valueOf)
+                .collect(java.util.stream.Collectors.toSet());
         destino.setLanguages(languageSet);
 
         Destino saved_destino = destinoService.create_destino(destino);

--- a/src/main/java/com/back/routopia/service/DestinoService.java
+++ b/src/main/java/com/back/routopia/service/DestinoService.java
@@ -5,6 +5,9 @@ import com.back.routopia.entity.Destino;
 import com.back.routopia.repositroy.DestinoRespository;
 import com.back.routopia.specification.DestinoSpecification;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
@@ -28,6 +31,15 @@ public class DestinoService {
         }
 
         return destinoRespository.findAll(spec);
+    }
+
+    public Page<Destino> list_all(Category category, String searchTerm, int page, int size) {
+        Specification<Destino> spec = Specification.where(DestinoSpecification.hasCategory(category));
+        if (searchTerm != null && !searchTerm.trim().isEmpty()) {
+            spec = spec.and(DestinoSpecification.searchByNameAndCity(searchTerm));
+        }
+        Pageable pageable = PageRequest.of(page, size);
+        return destinoRespository.findAll(spec, pageable);
     }
 
     public Optional<Destino> find_by_id(Long id) { return destinoRespository.findById(id); }


### PR DESCRIPTION
Implement pagination for the `find_all_destino` endpoint to support frontend requirements.

---
<a href="https://cursor.com/background-agent?bcId=bc-8fb9518a-94f3-4f67-add9-0ecdd6ccb7e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8fb9518a-94f3-4f67-add9-0ecdd6ccb7e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

